### PR TITLE
Add support for PCI devices and ne2000 card

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,4 +1,5 @@
 set disassembly-flavor intel
+set output-radix 16
 set prompt \033[31mgdb$ \033[0m
 target remote : 1234
 #set debug remote 1

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.log
 .gdb_history
 .idea
+net.pcap
 core
 hdd.img
 tags

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Comment it out if you do not whant kdbg support
-CONFIG_KDBG=y
+#CONFIG_KDBG=y
 
 export CFLAGS="-j 4"
 CC = gcc
@@ -12,7 +12,7 @@ ASM = nasm
 ASMFLAGS = -g3 -f elf
 RM = rm -f
 BOCHS = bochs
-QEMU = qemu-system-i386
+QEMU = sudo qemu-system-i386
 QEMU_SKIP_GRUB= -kernel kernel.bin
 QEMU_PARAMS = \
 			  -drive file=hdd.img,index=0,media=disk,format=raw \
@@ -25,9 +25,10 @@ OBJS = startup.o kernel.o i386.o port.o kinfo.o ring_buf.o \
 	   gdt.o idt.o int.o irq.o delay.o timer.o rtc.o \
 	   dev.o ansi.o kbd.o crt.o serial.o console.o tty.o \
 	   mem.o kheap.o \
-	   task.o thread.o sys.o syscall.o signal.o sysproc.o \
+	   task.o fork.o thread.o sys.o syscall.o signal.o sysproc.o \
 	   list.o bname.o canonize.o \
-	   hd.o hd_queue.o cofs.o vfs.o pipe.o sysfile.o
+	   hd.o hd_queue.o cofs.o vfs.o pipe.o sysfile.o \
+	   net.o pci.o driver.o ne2000.o
 
 ifdef CONFIG_KDBG
 OBJS += kdbg.o kdbg0.o
@@ -111,9 +112,17 @@ rung: diskimg
 	$(QEMU) $(QEMU_SKIP_GRUB) $(QEMU_PARAMS)
 
 debug: diskimg
-	$(QEMU) $(QEMU_SKIP_GRUB) $(QEMU_PARAMS) -display none -s -S
+	$(QEMU) $(QEMU_SKIP_GRUB) $(QEMU_PARAMS) -display none -s -S \
+		-netdev tap,helper=/usr/lib/qemu/qemu-bridge-helper,id=cOSnet\
+		-device ne2k_pci,netdev=cOSnet
+	#-netdev user,id=cOSnet -device ne2k_pci,netdev=cOSnet,mac=11:22:33:44:55:66
 
 run: diskimg
+	#sudo ip link add br0 type bridge
 	$(QEMU) $(QEMU_SKIP_GRUB) $(QEMU_PARAMS) -display none \
-		-serial telnet:127.0.0.1:1234,server,nowait
+		-serial telnet:127.0.0.1:1234,server,nowait \
+		-netdev tap,helper=/usr/lib/qemu/qemu-bridge-helper,id=cOSnet\
+		-device ne2k_pci,netdev=cOSnet
+		#-net nic,model=ne2k_pci -net tap,script=no,ifname=tap1
+		#-net nic,model=ne2k_pci -net dump,file=net.pcap -net user
 

--- a/README.txt
+++ b/README.txt
@@ -162,6 +162,9 @@ disk.
 | 0x20000000     | 0x30000000    | User heap (sys_sbrk, malloc),              |
 | UHEAP_START    | UHEAP_END     |  cloned on fork()                          |
 -------------------------------------------------------------------------------
+| 0xA0000000     | 0xB0000000    |  mmio_remap()                              |
+| MMIO_START     | MMIO_END      |                                            |
+-------------------------------------------------------------------------------
 | 0xD0000000     | 0xE0000000    | Kernel Heap (kernel sbrk, kernel malloc)   |
 | HEAP_START     | HEAP_END      |  linked on fork(), so every process "sees" |
 |                |               |  same kernel variables.                    |

--- a/bochsrc
+++ b/bochsrc
@@ -460,7 +460,7 @@ debugger_log: debugger.out
 #=======================================================================
 #com1: enabled=1, mode=term, dev=/dev/ttyp9
 com1: enabled=1, mode=file, dev=serial.out
-com2: enabled=1, mode=socket-server, dev=localhost:1234
+#com2: enabled=1, mode=socket-server, dev=localhost:1234
 
 #=======================================================================
 # PARPORT1, PARPORT2:

--- a/console.c
+++ b/console.c
@@ -76,6 +76,17 @@ void kprintf(char *fmt, ...)
     spin_unlock(&console_lock);
 }
 
+void hexdump(char *buf, int len)
+{
+    int i;
+    for (i = 0; i < len; i++) {
+        if (i && ((i % 16) == 0))
+            kprintf("\n");
+        kprintf("%02X ", buf[i] & 0xFF);
+    }
+    kprintf("\n");
+}
+
 /**
  * Send backspace
  */

--- a/console.h
+++ b/console.h
@@ -33,6 +33,7 @@ void panic(char *str, ...);
  */
 void kprintf(char *fmt, ...);
 
+void hexdump(char *buf, int len);
 /**
  * Write
  */

--- a/driver.c
+++ b/driver.c
@@ -1,0 +1,34 @@
+#include "console.h"
+#include "pci.h"
+#include "driver.h"
+#include "ne2000.h"
+
+struct driver *drivers[] = {
+    &ne2000_driver,
+    NULL,
+};
+
+int driver_init()
+{
+    int i, j;
+    struct pci_dev *pci_device;
+    struct driver *driver;
+
+    for (i = 0; i < pci_devs.idx; i++) {
+        pci_device = &pci_devs.devs[i];
+        for (j = 0; drivers[j]; j++) {
+            driver = drivers[j];
+            if (!driver->inited && driver->init) {
+                if (driver->init(driver) < 0) {
+                    continue;
+                }
+            }
+            if (driver->probe(pci_device) == 0) {
+                driver->attach(pci_device);
+            }
+        }
+    }
+
+    return 0;
+}
+

--- a/driver.h
+++ b/driver.h
@@ -1,0 +1,14 @@
+#ifndef _DRIVER_H
+#define _DRIVER_H
+
+struct driver {
+    const char *name;               /* Driver name */
+    bool inited;                    /* Was this driver initialized? */
+    int (*init)(struct driver *);   /* Called once, when driver starts */
+    int (*probe)(struct pci_dev *); /* Probes if a device is supported by this driver*/
+    int (*attach)(struct pci_dev *);/* Creates an instance of the driver and attach */
+};
+
+int driver_init();
+
+#endif

--- a/fork.asm
+++ b/fork.asm
@@ -1,0 +1,9 @@
+GLOBAL fork
+fork:
+    push ebp
+    mov ebp, esp
+    mov eax, 1
+    int 0x80
+    mov esp, ebp
+    pop ebp
+    ret

--- a/i386.asm
+++ b/i386.asm
@@ -73,6 +73,17 @@ outw:
     pop ebp
     ret
 
+GLOBAL outl
+outl:
+    push ebp
+    mov ebp, esp
+    mov dx, [ebp + 8]
+    mov eax, [ebp + 12]
+    out dx, eax
+    mov esp, ebp
+    pop ebp
+    ret
+
 GLOBAL inb
 inb:
     push ebp
@@ -89,6 +100,16 @@ inw:
     mov ebp, esp
     mov dx, [ebp + 8]
     in ax, dx
+    mov esp, ebp
+    pop ebp
+    ret
+
+GLOBAL inl
+inl:
+    push ebp
+    mov ebp, esp
+    mov dx, [ebp + 8]
+    in eax, dx
     mov esp, ebp
     pop ebp
     ret
@@ -186,7 +207,7 @@ patch_stack:
     sub edi, ecx          ; KERNEL_STACK_LOW
     shr ecx, 2            ; we read 4 bytes at a time
     mov esi, [stack_ptr]  ; save in esi current stack low
-    
+
     mov edx, edi          ; save in edx the difference 
     sub edx, esi          ; between old stack and the new stack
 

--- a/i386.h
+++ b/i386.h
@@ -63,14 +63,23 @@ void outb(uint16_t port, uint8_t byte);
 void outw(uint16_t port, uint16_t value);
 
 /**
+ * Outputs a long to port
+ */
+void outl(uint16_t port, uint32_t value);
+/**
  * Inputs a byte from port
  */
 uint8_t inb(uint16_t port);
 
 /**
- * Outputs a word to port
+ * Inputs a word from port
  */
 uint16_t inw(uint16_t port);
+
+/**
+ * Inputs a long to port
+ */
+uint32_t inl(uint16_t port);
 
 /**
  * Fills kinfo structure with code, start, data, bss, end, stack, stack_size

--- a/kernel.c
+++ b/kernel.c
@@ -28,6 +28,9 @@
 #include "dev.h"
 #include "tty.h"
 #include "kdbg.h"
+#include "net.h"
+#include "pci.h"
+#include "driver.h"
 
 uint32_t initrd_location, initrd_end;
 
@@ -80,6 +83,7 @@ void kmain(uint32_t magic, multiboot_header *mboot)
     serial_init();
     kbd_install();
     task_init();
+    syscall_init();
     if (fork() == 0)
         idle_task(); // no return
 #ifdef KDBG
@@ -87,7 +91,9 @@ void kmain(uint32_t magic, multiboot_header *mboot)
     kprintf("Waiting for remote GDB client.\n");
     BREAK();
 #endif
-    syscall_init();
+    net_init();
+    pci_init();
+    driver_init();
     // wait for the rtc interrupt to fire //
     while (!system_time)
         ;

--- a/mmio.c
+++ b/mmio.c
@@ -1,0 +1,38 @@
+#include "mem.h"
+#include "console.h"
+#include "mmio.h"
+
+/* Remapped Memory */
+#define MMIO_START 0xA0000000
+#define MMIO_END   0xB0000000
+
+virt_t mmio_ptr;
+
+/**
+ * Remaps physical memory at address addr, having size size, 
+ *  to arbitrary virtual memory in MMIO_START-MMIO_END region
+ * TODO: rename func to map_to_any or something and also the MMIO region,
+ * in order to be more generic.
+ */
+virt_t mmio_remap(phys_t addr, uint32_t size)
+{
+    uint32_t i;
+    virt_t ret;
+
+    if (size % PAGE_SIZE > 0)
+        size = ((size / PAGE_SIZE) + 1) * PAGE_SIZE;
+    if (mmio_ptr + size > MMIO_END)
+        return 0;
+    for (i = 0; i < size; i += PAGE_SIZE) {
+        map(mmio_ptr + i, addr + i, P_PRESENT | P_READ_WRITE);
+    }
+    ret = mmio_ptr;
+    mmio_ptr += i;
+
+    return ret;
+}
+
+void mmio_init()
+{
+    mmio_ptr = MMIO_START;
+}

--- a/mmio.h
+++ b/mmio.h
@@ -1,0 +1,11 @@
+#ifndef _MMIO_H
+#define _MMIO_H
+
+/* Remapped Memory */
+#define MMIO_START 0xA0000000
+#define MMIO_END   0xB0000000
+
+virt_t mmio_remap(phys_t addr, uint32_t size);
+void mmio_init();
+
+#endif

--- a/ne2000.c
+++ b/ne2000.c
@@ -1,0 +1,699 @@
+/**
+ * NE2000 - ne2000 PCI compatible network driver.
+ * DOCS: http://www.ethernut.de/pdf/8019asds.pdf
+ *       http://www.osdever.net./documents/DP8390Overview.pdf
+ * ---------------------------------------------------------------------------
+ * Copyright (c) 2018 MrBadNews <viorel dot irimia at gmail dot come>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <string.h>
+#include <stdlib.h>
+#include "console.h"
+#include "pci.h"
+#include "driver.h"
+#include "i386.h"
+#include "delay.h"
+#include "port.h"
+#include "ne2000.h"
+#include "irq.h"
+#include "net.h"
+
+/* Page 0 registers */
+enum {
+    NE_CR = 0x0,        /* Command Register */
+    NE_CLDA0 = 0x1,     /* Current Local DMA Address, low (r) */
+    NE_PSTART = 0x1,    /* Page START register (w) */
+    NE_CLDA1 = 0x02,    /* Current Local DMA Address, high (r) */
+    NE_PSTOP = 0x02,    /* Page STOP register (w)*/
+    NE_BNRY = 0x03,     /* Boundary pointer (r/w) */
+    NE_TSR = 0x04,      /* Transmit Status Register (r) */
+    NE_TPSR = 0x04,     /* Transmit Page Start Register (w) */
+    NE_NCR = 0x05,      /* Number of Collisions Register (r) */
+    NE_TBCR0 = 0x05,    /* Transmit Byte Count Register, low (r) */
+    NE_FIFO = 0x06,     /* FIFO register (r) */
+    NE_TBCR1 = 0x06,    /* Transmit Byte Count, high (r) */
+    NE_ISR = 0x07,      /* Interrupt Status Register (r/w) */
+    NE_CRDA0 = 0x08,    /* Current Remote DMA Address, high (r) */
+    NE_RSAR0 = 0x08,    /* Remote Start Address Register, low, (w) */
+    NE_CRDA1 = 0x09,    /* Current Remote DMA Address, high (r) */
+    NE_RSAR1 = 0x09,    /* Remote Start Address Register, high (w) */
+    NE_RBCR0 = 0x0A,    /* Remote Byte Count Register, low (r/w)*/
+    NE_RBCR1 = 0x0B,    /* Remote Byte Count Register, high (r/w) */
+    NE_RSR = 0x0C,      /* Receive Status Register (r) */
+    NE_RCR = 0x0C,      /* Receive Configuration Register (w) */
+    NE_CNTR0 = 0x0D,    /* Frame alignment error counter register (r) */
+    NE_TCR = 0x0D,      /* Transmit Configuration Register (w) */
+    NE_CNTR1 = 0x0E,    /* CRC Error Tally Counter Register (r) */
+    NE_DCR = 0x0E,      /* Data Configuration Register (w) */
+    NE_CNTR2 = 0x0F,    /* Missed packet counter (r) */
+    NE_IMR = 0x0F,      /* Interrupt Mask Register (w)*/
+} ne_regs_pg0;
+
+/* Page 1 registers */
+enum {
+    NE_PAR0 = 0x01,     /* Physical Address Registers 0-6 (r/w) */
+    NE_PAR1 = 0x02,
+    NE_PAR2 = 0x03,
+    NE_PAR3 = 0x04,
+    NE_PAR4 = 0x05,
+    NE_PAR5 = 0x06,
+    NE_CURR = 0x07,     /* Current Page Register (r/w) */
+    NE_MAR0 = 0x08,     /* Multicast Address Registers 0-6 (r/w)*/
+    NE_MAR1 = 0x09,
+    NE_MAR2 = 0x0A,
+    NE_MAR3 = 0x0B,
+    NE_MAR4 = 0x0C,
+    NE_MAR5 = 0x0D,
+    NE_MAR6 = 0x0E,
+    NE_MAR7 = 0x0F,
+} ne_regs_pg1;
+
+/* Page 2 registers */
+enum {
+    NE_RNPP = 0x03,     /* Remote Next Packet Pointer */
+    NE_LNPP = 0x05,     /* Local Next Packet Pointer */
+    NE_ACU = 0x06,      /* Address Counter Upper */
+    NE_ACL = 0x07,      /* Address Counter Lower */
+} ne_regs_pg2;
+
+/* Command register (CR) bits, r/w any page */
+enum {
+    NE_CR_STP = 0001,   /* Stop */
+    NE_CR_STA = 0002,   /* Start */
+    NE_CR_TXP = 0004,   /* Transmit Packet */
+    NE_CR_RD0 = 0010,   /* Remote DMA command, bit 0 */
+    NE_CR_RD1 = 0020,   /* Remote DMA command, bit 1 */
+    NE_CR_RD2 = 0040,   /* Remote DMA command, bit 2 */
+    NE_CR_PS0 = 0100,   /* Page Select bit 0 */
+    NE_CR_PS1 = 0200,   /* Page Select bit 1 */
+} ne_cr_bits;
+
+#define NE_CR_READ (NE_CR_RD0)   /* Remote read command */
+#define NE_CR_WRITE (NE_CR_RD1)  /* Remote write command */
+#define NE_CR_SEND (NE_CR_RD0 | NE_CR_RD1) /* Send packet command */
+#define NE_CR_DMA_ABORT (NE_CR_RD2)  /* Abort/complete remote DMA */
+#define NE_CR_DMA_WR (NE_CR_RD1)
+#define NE_CR_DMA_RD (NE_CR_RD0)
+#define NE_CR_PG0 0x0
+#define NE_CR_PG1 (NE_CR_PS0)
+#define NE_CR_PG2 (NE_CR_PS0 | NE_CR_PS1)
+
+/* Interrupt Status Register (ISR) bits, r/w in page 0 */
+enum {
+    NE_ISR_PRX = 0001,  /* Packet received with no error */
+    NE_ISR_PTX = 0002,  /* Packet transmitted with no error */
+    NE_ISR_RXE = 0004,  /* set on rx errors: CRC, frame align, missed packet */
+    NE_ISR_TXE = 0010,  /* set on tx errors */
+    NE_ISR_OVW = 0020,  /* set when rx buffer exhausted */
+    NE_ISR_CNT = 0040,  /* set when MSB of tally counters has been set */
+    NE_ISR_RDC = 0100,  /* set when DMA op completed */
+    NE_ISR_RST = 0200,  /* reset status */
+} ne_isr_bits;
+
+/* IMR(w pg0, r pg2) has same bits as ISR, setting individual bits to 1
+ * will enable coresponding interrupts. */
+enum {
+    NE_IMR_PRXE = 0001, /* Packet Reveived interrupt Enable */
+    NE_IMR_PTXE = 0002, /* Packet Transmitted interrupt Enable */
+    NE_IMR_RXEE = 0004, /* Receive Error interrupt Enable */
+    NE_IMR_TXEE = 0010, /* Transmit Error interrupt Enable */
+    NE_IMR_OVWE = 0020, /* OVerwrite Warning interrupt Enable */
+    NE_IMR_CNTE = 0040, /* CouNTer overflow interrupt Enable */
+    NE_IMR_RDCE = 0100, /* Remote DMA Complete interrupt Enable */
+} ne_imr_bits;
+
+/* Data Configuration Register (DCR) bits, w in pg0, r in pg2*/
+enum {
+    NE_DCR_WTS = 0001, /* Word Transfer Select; 1: word, 0: byte DMA transfer */
+    NE_DCR_BOS = 0002, /* Byte Order Select; 0: MSB on 15-8 */
+    NE_DCR_LAS = 0004, /* Long Address Select */
+    NE_DCR_LS  = 0010, /* Loopback Select; 0 loopback, 1 normal */
+    NE_DCR_ARM = 0020, /* Auto-initialize remote */
+    NE_DCR_FT0 = 0040, /* FIFO Threshold select, bit 0 */
+    NE_DCR_FT1 = 0100, /* FIFO Threshold select, bit 1 */
+} ne_dcr_bits;
+
+#define NE_DCR_2B 0
+#define NE_DCR_4B (NE_DCR_FT1)
+#define NE_DCR_8B (NE_DCR_FT0)
+#define NE_DCR_12B (NE_DCR_FT0 | NE_DCR_FT1)
+
+/* Transmit Configuration Register (TCR) bits, w in pg0, r in pg 2 */
+enum {
+    NE_TCR_NORMAL = 0000,
+    NE_TCR_CRC = 0001, /* Inhibit transmitter CRC, if set */
+    NE_TCR_LB0 = 0002, /* Loopback control, bit 0 */
+    NE_TCR_LB1 = 0004, /* Loopback control, bit 1 */
+    NE_TCR_ATD = 0010, /* Auto Transmit Disable */
+    NE_TCR_OFST= 0020, /* Collision Offset Enable */
+} ne_tcr_bits;
+
+/* Transmit Status Register (TSR) bits, r in pg0 */
+enum {
+    NE_TSR_PTX = 0001, /* Transmit completes with no errors */
+    NE_TSR_COL = 0004, /* Transmission collided with other station */
+    NE_TSR_ABT = 0010, /* Transmission aborted */
+    NE_TSR_CRS = 0020, /* Carrier Sense Lost */
+    NE_TSR_FU  = 0040,
+    NE_TSR_CDH = 0100, /* CD Heartbeat */
+    NE_TSR_OWC = 0200, /* Out of Window Collision */
+} ne_tsr_bits;
+
+/* Receiver Configuration Register (RCR) bits, w in pg0, r in pg2 */
+enum {
+    NE_RCR_SEP = 0001, /* Accept packets with errors */
+    NE_RCR_AR =  0002, /* Accept packets with length < 64 bytes */
+    NE_RCR_AB =  0004, /* Accept packets with broadcast destination address */
+    NE_RCR_AM =  0010, /* Accept packets with multicast destination address */
+    NE_RCR_PRO = 0020, /* Promiscuous mode if 1, else accept only PAR0-5 addr */
+    NE_RCR_MON = 0040, /* Monitor mode */
+} ne_rcr_bits;
+
+/* Receiver Status Register (RSR) bits, r in pg0 */
+enum {
+    NE_RSR_PRX = 0001, /* Received with no errors */
+    NE_RSR_CRC = 0002, /* Packet received with CRC errors */
+    NE_RSR_FAE = 0004, /* Frame Alignment Error */
+    NE_RSR_FO  = 0010, /* Fifo Overrun */
+    NE_RSR_MPA = 0020, /* Missed Packet */
+    NE_RSR_PHY = 0040, /* Physical addr, set on multicast or broadcast packet */
+    NE_RSR_DIS = 0100, /* Receiver Disabled */
+    NE_RSR_DFR = 0200, /* Defferring. Set when carrier or collision detected. */
+} ne_rsr_bits;
+
+/* XXX size and start of on chip memory */
+#define NE_DATA 0x10
+#define NE_PG_SIZE 256      /* Size of a page, in bytes */
+#define NE_START 0x4000     /* On chip start memory. QEMU starts at 16k */
+#define NE_DATA_SIZE 0x4000 /* Size of the on chip buffer, 16k. QEMU use 32k */
+#define NE_RESET 0x1F
+
+/* Reserve 8 256 bytes pages for TX buffer. */
+#define TX_START (NE_START / NE_PG_SIZE)
+#define TX_SIZE 8
+/* RX ring buffer starts after TX buffer. Values are in 256 pages. */
+#define RX_START (TX_START + TX_SIZE)
+#define RX_STOP (TX_START + (NE_DATA_SIZE / NE_PG_SIZE))
+
+#define RESET_RETRIES 0x1000
+#define MAC_LEN 6
+#define ARR_LEN(arr) ((int)(sizeof(arr) / sizeof(*arr)))
+
+void ne2000_handler(struct iregs *regs);
+int ne2000_up(struct pci_dev *dev);
+int ne2000_send(struct pci_dev *dev, void *buf, uint16_t len);
+int ne2000_recv(struct pci_dev *dev);
+
+struct driver ne2000_driver;
+
+struct eth_stats {
+    uint32_t sent;  /* Number of successfuly transmitted frames */
+    uint32_t sent_errs;
+    uint32_t collisions;
+    uint32_t aborted_errs;
+    uint32_t carrier_errs;
+    uint32_t underrruns;
+    uint32_t heartbeat_errs;
+    uint32_t sent_window_errs;
+    uint32_t recv;
+    uint32_t recv_errs;
+    uint32_t recv_crc_errs;
+    uint32_t recv_frame_errs;
+    uint32_t recv_missed;
+    uint32_t recv_overruns;
+};
+
+/* ne2000 structure */
+struct ne2000 {
+    int addr;   /* Card IO base address */
+    int irq;
+    int nic;    /* NIC id */
+    spin_lock_t tx_lock;
+    uint8_t mac[MAC_LEN];   /* MAC address */
+    uint8_t attached;   /* Is the driver attached to card? */
+    uint8_t up;         /* Is the card up? */
+    uint8_t tx_pstart;  /* TX (256) page 0. */
+    uint8_t rx_pstart;  /* RX start page 0 */
+    uint8_t rx_pstop;   /* RX end page */
+    struct eth_stats stats;
+};
+
+struct recv_hdr {
+    uint8_t stat;
+    uint8_t next;
+    uint8_t rbcl;
+    uint8_t rbch;
+};
+
+/* List of ne2000 compatible devices */
+struct pci_id ne2000_compat[] = {
+    { 0x10ec, 0x8029 }, // qemu RTL8029
+};
+
+/* An ARP test packet */
+uint8_t test_packet[] = {
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0x52, 0x54, 0x00, 0x12, 0x34, 0x56,
+    0x08, 0x06,
+    0x00, 0x01,
+    0x08, 0x00,
+    0x06, 
+    0x04,
+    0x00, 0x01,
+    0x52, 0x54, 0x00, 0x12, 0x34, 0x56,
+    10, 0, 2, 15,
+    0, 0, 0, 0, 0, 0,
+    10, 0, 2, 1,
+};
+
+/**
+ * Writes size bytes from buf to chip memory ne_addr
+ * Returns number of bytes written
+ */
+int ne2000_put(struct pci_dev *dev, void *buf, int ne_addr, int size)
+{
+    int n;
+    uint16_t c;
+    struct ne2000 *ne = dev->priv;
+    if (!ne->up)
+        return -1;
+    outb(ne->addr + NE_RBCR0, size & 0xFF);
+    outb(ne->addr + NE_RBCR1, (size >> 8) & 0xFF);
+    outb(ne->addr + NE_RSAR0, ne_addr & 0xFF);
+    outb(ne->addr + NE_RSAR1, (ne_addr >> 8) & 0xFF);
+    outb(ne->addr + NE_CR, NE_CR_PG0 | NE_CR_DMA_WR | NE_CR_STA);
+    n = port_write(ne->addr + NE_DATA, buf, size / 2);
+    n = n << 1;
+    if (size & 0x1) {
+        c = *((char *) buf + n);
+        outw(ne->addr + NE_DATA, c);
+        n++;
+    }
+
+    return n;
+}
+
+/**
+ * Reads size bytes from chip memory addr into buf
+ * Returns number of bytes read
+ */
+int ne2000_get(struct pci_dev *dev, void *buf, int ne_addr, int size)
+{
+    int n;
+    uint16_t c;
+    struct ne2000 *ne = dev->priv;
+    if (!ne->up)
+        return -1;
+
+    outb(ne->addr + NE_RBCR0, size & 0xFF);
+    outb(ne->addr + NE_RBCR1, (size >> 8) & 0xFF);
+    outb(ne->addr + NE_RSAR0, ne_addr & 0xFF);
+    outb(ne->addr + NE_RSAR1, (ne_addr >> 8) & 0xFF);
+    outb(ne->addr + NE_CR, NE_CR_PG0 | NE_CR_DMA_RD | NE_CR_STA);
+
+    n = port_read(ne->addr + NE_DATA, buf, size / 2);
+    n = n << 1;
+    if (size & 0x1) {
+        c = inw(ne->addr + NE_DATA);
+        *((char *) buf + n) = (char) c;
+        n++;
+    }
+
+    return n;
+}
+/* Init driver. Called once per ne2000 type. */
+static int ne2000_init(struct driver *driver)
+{
+    driver->inited = true;
+    return 0;
+}
+
+/* Reset the card */
+static int ne2000_reset(uint16_t ioaddr)
+{
+    int i;
+
+    outb(ioaddr + NE_RESET, inb(ioaddr + NE_RESET)); /* Reset card */
+    for (i = 0; i < RESET_RETRIES; i++)
+        if ((inb(ioaddr + NE_ISR) & NE_ISR_RST) != 0) /* Wait for reset */
+            break;
+
+    return (i == RESET_RETRIES ? -1 : 0);
+}
+
+/**
+ * Gets the base card io address from dev
+ * Usually this should be first bar, but just in case
+ */
+static uint16_t ne2000_getio(struct pci_dev *dev)
+{
+    int i;
+    uint16_t ioaddr = -1;
+
+    for (i = 0; i < ARR_LEN(dev->bars); i++) {
+        if (dev->bars[i].type == PCI_BAR_IO) {
+            ioaddr = dev->bars[i].base;
+            break;
+        }
+    }
+
+    return ioaddr;
+}
+
+/**
+ * Probe if pci device can be handled by this driver
+ */
+static int ne2000_probe(struct pci_dev *dev)
+{
+    int i, ioaddr;
+
+    for (i = 0; i < ARR_LEN(ne2000_compat); i++)
+        if (ne2000_compat[i].vendor_id == dev->vendor_id
+            && ne2000_compat[i].device_id == dev->device_id)
+            break;
+    if (i == ARR_LEN(ne2000_compat))
+        return -1;
+
+    if ((ioaddr = ne2000_getio(dev)) < 0)
+        return -1;
+
+    if (ne2000_reset(ioaddr) < 0)
+        return -1;
+
+    kprintf("Found ne2000 on bus:%#x, slot: %#x, "
+            "vendor_id: %#x, device_id: %#x\n",
+            dev->bus, dev->slot, dev->vendor_id, dev->device_id);
+
+    return 0;
+}
+
+/**
+ * Attach an instance of the driver to pci device
+ */
+int ne2000_attach(struct pci_dev *dev)
+{
+    unsigned int i;
+    struct ne2000 *ne = NULL;
+
+    if (!(ne = calloc(1, sizeof(*ne))))
+        return -1;
+    if ((ne->addr = ne2000_getio(dev)) < 0) {
+        free(ne);
+        return -1;
+    }
+    if (ne2000_reset(ne->addr) < 0) {
+        free(ne);
+        return -1;
+    }
+    ne->irq = dev->irq;
+
+    /* Configure TCR, DCR and put receiver in monitor mode */
+    outb(ne->addr + NE_TCR, 0);
+    outb(ne->addr + NE_RCR, NE_RCR_MON);
+    outb(ne->addr + NE_DCR, NE_DCR_8B | NE_DCR_LS | NE_DCR_WTS);
+
+    /* Do a read, to get MAC address */
+    outb(ne->addr + NE_RBCR0, MAC_LEN * 2);
+    outb(ne->addr + NE_RBCR1, 0);
+    outb(ne->addr + NE_RSAR0, 0);
+    outb(ne->addr + NE_RSAR1, 0);
+    outb(ne->addr + NE_CR, NE_CR_READ | NE_CR_PG0 |  NE_CR_STA);
+
+    for (i = 0; i < MAC_LEN; i++)
+        ne->mac[i] = inb(ne->addr + NE_DATA);
+
+    kprintf("MAC address: %02x:%02x:%02x:%02x:%02x:%02x\n",
+            ne->mac[0], ne->mac[1], ne->mac[2],
+            ne->mac[3], ne->mac[4], ne->mac[5]);
+
+    irq_install_handler(ne->irq, ne2000_handler);
+    ne->attached = 1;
+    /* Register it to global network interface array */
+    ne->nic = nics++;
+    net_ifaces[ne->nic].id = ne->nic;
+    net_ifaces[ne->nic].priv = ne;
+    dev->priv = ne;
+
+    if (ne2000_up(dev) < 0) {
+        kprintf("Cannot bring up the network interface\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+/**
+ * Bring the card up
+ */
+int ne2000_up(struct pci_dev *dev)
+{
+    int i;
+    struct ne2000 *ne = dev->priv;
+
+    if (!ne->attached)
+        return -1;
+
+    ne->tx_pstart = TX_START;
+    ne->rx_pstart = RX_START;
+    ne->rx_pstop = RX_STOP;
+
+    outb(ne->addr + NE_CR, NE_CR_DMA_ABORT | NE_CR_STP | NE_CR_PG0);
+    outb(ne->addr + NE_DCR, NE_DCR_WTS | NE_DCR_8B | NE_DCR_LS);
+    outb(ne->addr + NE_RBCR0, 0);
+    outb(ne->addr + NE_RBCR1, 0);
+    outb(ne->addr + NE_RCR, NE_RCR_AB);
+    outb(ne->addr + NE_TCR, NE_TCR_LB0);
+
+    outb(ne->addr + NE_BNRY, ne->rx_pstart);
+    outb(ne->addr + NE_PSTART, ne->rx_pstart);
+    outb(ne->addr + NE_PSTOP, ne->rx_pstop);
+
+    outb(ne->addr + NE_ISR, 0xFF);
+    outb(ne->addr + NE_IMR, NE_IMR_PRXE | NE_IMR_PTXE | NE_IMR_RXEE
+            | NE_IMR_TXEE | NE_IMR_OVWE | NE_IMR_PRXE);
+
+    outb(ne->addr + NE_CR, NE_CR_PG1 | NE_CR_DMA_ABORT | NE_CR_STP);
+
+    for (i = 0; i < MAC_LEN; i++)
+        outb(ne->addr + NE_PAR0 + i, ne->mac[i]);
+    for (i = NE_MAR0; i < NE_MAR7; i++)
+        outb(ne->addr + i, 0xFF);
+    outb(ne->addr + NE_CURR, ne->rx_pstart + 1);
+    outb(ne->addr + NE_CR, NE_CR_DMA_ABORT | NE_CR_STA | NE_CR_PG0);
+    outb(ne->addr + NE_TCR, NE_TCR_NORMAL);
+
+    inb(ne->addr + NE_CNTR0);
+    inb(ne->addr + NE_CNTR1);
+    inb(ne->addr + NE_CNTR2);
+
+    ne->up = 1;
+#if 0
+    ne2000_send(dev, test_packet, sizeof(test_packet));
+#endif
+
+    return 0;
+}
+
+/**
+ * Bring the card down
+ */
+int ne2000_down(struct pci_dev *dev)
+{
+    struct ne2000 *ne = dev->priv;
+    if (!ne->up)
+        return -1;
+    outb(ne->addr + NE_CR, NE_CR_PG0 | NE_CR_DMA_ABORT | NE_CR_STP);
+    outb(ne->addr + NE_IMR, 0);
+    outb(ne->addr + NE_ISR, 0xFF);
+    ne->up = 0;
+
+    return 0;
+}
+
+/**
+ * Card interrupt handler
+ */
+void ne2000_handler(struct iregs *regs)
+{
+    int i, irq;
+    int isr, tsr;
+    struct pci_dev *dev;
+    struct ne2000 *ne = NULL;
+
+    irq = regs->int_no - 0x20;
+    for (i = 0; i < pci_devs.idx; i++) {
+        dev = &pci_devs.devs[i];
+        if (dev->irq == irq) {
+            ne = dev->priv;
+            break;
+        }
+    }
+    if (!ne)
+        return;
+
+    isr = inb(ne->addr + NE_ISR);
+    outb(ne->addr + NE_ISR, 0xFF);      /* ACK interrupt */
+
+    if (isr & NE_ISR_PTX) {
+        ne->stats.sent++;
+    } else if (isr & NE_ISR_TXE) {
+        tsr = inb(ne->addr + NE_TSR);
+        if (tsr & NE_TSR_COL)
+            ne->stats.collisions++;
+        if (tsr & NE_TSR_ABT)
+            ne->stats.aborted_errs++;
+        if (tsr & NE_TSR_CRS)
+            ne->stats.carrier_errs++;
+        if (tsr & NE_TSR_FU)
+            ne->stats.underrruns++;
+        if (tsr & NE_TSR_CDH)
+            ne->stats.heartbeat_errs++;
+        if (tsr & NE_TSR_OWC)
+            ne->stats.sent_window_errs++;
+    }
+    if (isr & (NE_ISR_PTX | NE_ISR_TXE))
+        spin_unlock(&ne->tx_lock);
+    if (isr & NE_ISR_PRX) {
+        ne2000_recv(dev);
+    } else if (isr & NE_ISR_RXE) {
+        ne->stats.recv_errs++;
+    }
+    if (isr & NE_ISR_CNT) {
+        ne->stats.recv_frame_errs += inb(ne->addr + NE_CNTR0);
+        ne->stats.recv_crc_errs += inb(ne->addr + NE_CNTR1);
+        ne->stats.recv_missed += inb(ne->addr + NE_CNTR2);
+    }
+    //kprintf("ne2000 interrupt [isr: %b]\n", isr);
+}
+
+/**
+ * Send a packet in buf
+ */
+int ne2000_send(struct pci_dev *dev, void *buf, uint16_t len)
+{
+    struct ne2000 *ne = dev->priv;
+    if (!ne->up)
+        return -1;
+
+    spin_lock(&ne->tx_lock);
+    ne2000_put(dev, buf, ne->tx_pstart * NE_PG_SIZE, len);
+
+    outb(ne->addr + NE_TPSR, ne->tx_pstart);
+    outb(ne->addr + NE_TBCR0, len & 0xFF);
+    outb(ne->addr + NE_TBCR1, (len >> 8) & 0xFF);
+    outb(ne->addr + NE_CR, NE_CR_TXP | NE_CR_STA);
+
+    return 0;
+}
+
+static int ne2000_recv_frame(struct pci_dev *dev, int page, int size)
+{
+    int pg_end, size1, n;
+    struct net_buf *net_buf;
+    struct ne2000 *ne = dev->priv;
+
+    if (!ne->up)
+        return -1;
+
+    if (!(net_buf = net_buf_alloc(size, ne->nic)))
+        return -1;
+    pg_end = page + size / NE_PG_SIZE;
+    if (pg_end >= ne->rx_pstop) {
+        size1 = (ne->rx_pstop - page) * NE_PG_SIZE;
+        n = ne2000_get(dev, net_buf->buf, page * NE_PG_SIZE+4, size1);
+        n += ne2000_get(dev, net_buf->buf + size1, ne->rx_pstart * NE_PG_SIZE,
+                size - size1);
+    } else {
+        n = ne2000_get(dev, net_buf->buf, page * NE_PG_SIZE+4, size);
+    }
+    if (!netq_push(net_buf)) {
+        net_buf_free(net_buf);
+        return -1;
+    }
+    ne->stats.recv++;
+
+    return n;
+}
+
+/**
+ * Called from interrupt, to grab a frame from the device
+ * and push it into network queue (netq)
+ */
+int ne2000_recv(struct pci_dev *dev)
+{
+    int bnry, curr, next, size;
+    struct recv_hdr recv_hdr;
+    struct ne2000 *ne = dev->priv;
+
+    if (!ne->up)
+        return -1;
+
+    for (;;) {
+        outb(ne->addr + NE_CR, NE_CR_PG1 | NE_CR_DMA_ABORT | NE_CR_STA);
+        curr = inb(ne->addr + NE_CURR);
+        outb(ne->addr + NE_CR, NE_CR_PG0 | NE_CR_DMA_ABORT | NE_CR_STA);
+        bnry = inb(ne->addr + NE_BNRY);
+        bnry += 1;
+        if (bnry == ne->rx_pstop)
+            bnry = ne->rx_pstart;
+        if (curr == bnry)
+            break;
+        ne2000_get(dev, &recv_hdr, bnry * NE_PG_SIZE, sizeof(recv_hdr));
+#if 0
+        kprintf("curr: %x, bnry: %x\n", curr, bnry);
+        kprintf("pstart: %x, pstop: %x\n", ne->rx_pstart, ne->rx_pstop);
+        kprintf("next: %x, stat: %x, rbch: %x, rbcl: %x\n", 
+                recv_hdr.next, recv_hdr.stat, recv_hdr.rbch, recv_hdr.rbcl);
+#endif
+        size = (((uint32_t)recv_hdr.rbch) << 8 | recv_hdr.rbcl);
+        size -= sizeof(recv_hdr);
+        next = recv_hdr.next;
+
+        if (size < 60 || size > 1518) {
+            kprintf("invalid packet size: %d\n", size);
+            next = curr;
+        } else if (next < ne->rx_pstart || next > ne->rx_pstop) {
+            kprintf("invalid next frame: %d\n", next);
+            next = curr;
+        } else if (recv_hdr.stat & NE_RSR_FO) {
+            kprintf("FIFO overrun!\n");
+            ne->stats.recv_overruns++;
+            next = curr;
+        } else if (recv_hdr.stat & NE_RSR_PRX) {
+            ne2000_recv_frame(dev, bnry, size);
+        }
+        if (next == ne->rx_pstart)
+            next = ne->rx_pstop - 1;
+        else 
+            next--;
+
+        outb(ne->addr + NE_BNRY, next);
+    }
+
+    return 0;
+}
+
+struct driver ne2000_driver = {
+    .name = "ne2000 PCI",
+    .inited = false,
+    .init = ne2000_init,
+    .probe = ne2000_probe,
+    .attach = ne2000_attach,
+};
+

--- a/ne2000.h
+++ b/ne2000.h
@@ -1,0 +1,6 @@
+#ifndef _NE2000_H
+#define _NE2000_H
+
+extern struct driver ne2000_driver;
+
+#endif

--- a/net.c
+++ b/net.c
@@ -1,0 +1,97 @@
+#include <stdlib.h>
+#include <string.h>
+#include "console.h"
+#include "net.h"
+
+#define NB_MAX_SIZE 2000    /* Maximum size of a network buffer, in bytes */
+#define NETQ_MAX_ITEMS 256  /* Maximum number of buffers in network queue */
+
+/* Global network queue */
+struct net_queue *netq;
+
+/* Global array of network interfaces */
+struct net_iface net_ifaces[MAX_NET_IFACES];
+
+/* Global number of network interfaces */
+int nics;
+
+struct net_buf *net_buf_alloc(int size, int nic_id)
+{
+    struct net_buf *buf = NULL;
+
+    if (netq->list->num_items >= NETQ_MAX_ITEMS) {
+        kprintf("net_buf_alloc: queue full\n");
+        return NULL;
+    }
+    if (size > NB_MAX_SIZE) {
+        kprintf("net_buf_alloc: buffer too big (%d)\n", NB_MAX_SIZE);
+        return NULL;
+    }
+    if (!(buf = malloc(sizeof(*buf) + size))) {
+        kprintf("net_buf_alloc: out of memory\n");
+        return NULL;
+    }
+    buf->nic = nic_id;
+    buf->buf = buf + 1;
+    buf->size = size;
+
+    return buf;
+}
+
+void net_buf_free(void *buf)
+{
+    free(buf);
+}
+
+node_t *netq_push(struct net_buf *buf)
+{
+    node_t *node = NULL;
+
+    spin_lock(&netq->lock);
+    if (netq->list->num_items >= NETQ_MAX_ITEMS) {
+        kprintf("Too many net_bufs\n");
+        goto ret;
+    }
+    node = list_add(netq->list, buf);
+
+ret:
+    spin_unlock(&netq->lock);
+    {
+        kprintf("incoming: %d, size: %d\n", netq->list->num_items, buf->size);
+        hexdump(buf->buf, buf->size);
+    }
+    return node;
+}
+
+struct net_buf *netq_shift()
+{
+    struct net_buf *buf = NULL;
+
+    if (netq->list->num_items == 0)
+        goto ret;
+
+    spin_lock(&netq->lock);
+    buf = netq->list->head->data;
+    list_del(netq->list, netq->list->head);
+
+ret:
+    spin_unlock(&netq->lock);
+    return buf;
+}
+
+int net_init()
+{
+    nics = 0;
+    /* Init network queue */
+    if (!(netq = calloc(1, sizeof(*netq)))) {
+        kprintf("netq_init: out of memory\n");
+        return -1;
+    }
+    if (!(netq->list = list_open(NULL))) {
+        kprintf("netq_init: can't initialize queue\n");
+        return -1;
+    }
+
+    return 0;
+}
+

--- a/net.h
+++ b/net.h
@@ -1,0 +1,53 @@
+#ifndef _NET_H
+#define _NET_H
+
+#include "list.h"
+#include "i386.h"
+
+#define MAX_NET_IFACES 4
+
+/* Network interface */
+struct net_iface {
+    int id;
+    void *priv;
+};
+
+/* A network buffer */
+struct net_buf {
+    void *buf;
+    int size;
+    int nic;
+};
+
+/* Network queue */
+struct net_queue {
+    list_t *list;
+    spin_lock_t lock;
+};
+
+/* The network receive queue */
+extern struct net_queue *netq;
+
+/* Array of network interfaces */
+extern struct net_iface net_ifaces[MAX_NET_IFACES];
+
+/* Number of physical nics in the system */
+extern int nics;
+
+/* Allocates a buffer */
+struct net_buf *net_buf_alloc(int len, int nic_id);
+
+/* Free a buffer */
+void net_buf_free(void *buf);
+
+/* Push buffer to network queue */
+node_t *netq_push(struct net_buf *buf);
+
+/* Gets first buffer from network queue */
+struct net_buf *netq_shift();
+
+/* Initialize the network structures */
+int net_init();
+
+#endif
+

--- a/pci.c
+++ b/pci.c
@@ -1,0 +1,236 @@
+#include <sys/types.h>
+#include <string.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include "vfs.h"
+#include "console.h"
+#include "i386.h"
+#include "pci.h"
+
+#define PCI_CFG_ADDR 0xCF8
+#define PCI_CFG_DATA 0xCFC
+
+#define PCI_VENDOR_ID 0x0
+#define PCI_DEVICE_ID 0x02
+#define PCI_CLASS 0x0B
+#define PCI_SUBCLASS 0x0A
+#define PCI_HEADER_TYPE 0x0E
+#define PCI_BAR0 0x10
+#define PCI_BAR1 0x14
+#define PCI_BAR2 0x18
+#define PCI_BAR3 0x1C
+#define PCI_BAR4 0x20
+#define PCI_BAR5 0x24
+#define PCI_ROM_ADDR 0x30
+#define PCI_INT_LINE 0x3C
+
+struct pci_devs pci_devs;
+
+char *pci_class_codes[] = {
+    "Unclassified device",
+    "Mass storage controller",
+    "Network controller",
+    "Display controller",
+    "Multimedia controller",
+    "Memory controller",
+    "Bridge",
+    "Communication controller",
+    "Generic system peripheral",
+    "Input device controller",
+    "Docking station",
+    "Processor",
+    "Serial bus controller",
+    "Wireless controller",
+    "Intelligent controller",
+    "Satellite communications controller",
+    "Encryption controller",
+    "Signal processing controller",
+    "Processing accelerators",
+    "Non-Essential Instrumentation",
+    "Coprocessor",
+    "Unassigned class",
+};
+#define PCI_CFG_CMD(bus, slot, func, offs) \
+    (0x80000000 | (bus << 16) | (slot << 11) | (func << 8) | (offs & ~3))
+
+static uint8_t pci_cfg_readb(int bus, int slot, int func, int offs)
+{
+    uint8_t ret;
+    outl(PCI_CFG_ADDR, PCI_CFG_CMD(bus, slot, func, offs));
+    ret = inb(PCI_CFG_DATA + (offs & 3));
+    return ret;
+}
+
+static uint16_t pci_cfg_readw(int bus, int slot, int func, int offs)
+{
+    uint16_t ret;
+    outl(PCI_CFG_ADDR, PCI_CFG_CMD(bus, slot, func, offs));
+    ret = inw(PCI_CFG_DATA + (offs & 2));
+    return ret;
+}
+
+static uint32_t pci_cfg_readl(int bus, int slot, int func, int offs)
+{
+    outl(PCI_CFG_ADDR, PCI_CFG_CMD(bus, slot, func, offs));
+    return inl(PCI_CFG_DATA);
+}
+
+static void pci_cfg_writel(int bus, int slot, int func, int offs, uint32_t val)
+{
+    outl(PCI_CFG_ADDR, PCI_CFG_CMD(bus, slot, func, offs));
+    outl(PCI_CFG_DATA, val);
+}
+
+static uint32_t pci_bar_size(int bus, int slot, int func, int bar)
+{
+    uint32_t size, mask, addr;
+    addr = pci_cfg_readl(bus, slot, func, bar);
+    pci_cfg_writel(bus, slot, func, bar, ~0);
+    mask = pci_cfg_readl(bus, slot, func, bar);
+    size = ~(mask & ~0xF) + 1;
+    pci_cfg_writel(bus, slot, func, bar, addr);
+    return size;
+}
+
+static int pci_scan()
+{
+    uint16_t bus, slot, func, vendor_id, class_id;
+    int bar, i;
+    uint32_t addr, low, hi;
+    struct pci_dev *p;
+    struct bar *b;
+
+    for (bus = 0; bus <= 255; bus++) {
+        for (slot = 0; slot < 32; slot++) {
+            for (func = 0; func < 8; func++) {
+                vendor_id = pci_cfg_readw(bus, slot, func, PCI_VENDOR_ID);
+                if (vendor_id == 0xFFFF)
+                    continue;
+                class_id = pci_cfg_readb(bus, slot, func, PCI_CLASS);
+                /* Skip PCI bridge */
+                if (class_id == 0x06)
+                    continue;
+                p = &pci_devs.devs[pci_devs.idx++];
+                if (pci_devs.idx == PCI_MAX_DEVS) {
+                    kprintf("PCI devs; not enough slots\n");
+                    return -1;
+                }
+                p->bus = bus;
+                p->slot = slot;
+                p->func = func;
+                p->vendor_id = vendor_id;
+                p->device_id = pci_cfg_readw(bus, slot, func, PCI_DEVICE_ID);
+                p->class = class_id;
+                p->subclass = pci_cfg_readb(bus, slot, func, PCI_SUBCLASS);
+
+                for (bar = PCI_BAR0, i = 0; bar <= PCI_BAR5; bar += 4) {
+                    addr = pci_cfg_readl(bus, slot, func, bar);
+                    if (addr == 0)
+                        continue;
+                    b = &p->bars[i++];
+                    b->type = addr & 0x1;
+                    /* IO type BAR - base is a port */
+                    if (b->type == PCI_BAR_IO) {
+                        b->base = (addr & ~3);
+                    }
+                    /* Memory type BAR - base is memory */
+                    else {
+                        b->subtype = (addr & 6) >> 1;
+                        /* 64 bit bar type, if base address is mapped into the
+                         * first 4 GB, we can use it */
+                        if (b->subtype == PCI_BAR_MM64) {
+                            low = (addr & ~0xF);
+                            hi = pci_cfg_readl(bus, slot, func, bar + 4);
+                            if (hi != 0) {
+                                kprintf("Cannot use 64 bit bar h:%#x, l:%#x\n",
+                                        hi, low);
+                                continue;
+                            }
+                            b->base = low;
+                            b->size = pci_bar_size(bus, slot, func, bar);
+                            bar += 4;
+                        }
+                        /* 32 bit bar type */
+                        else if (b->subtype == PCI_BAR_MM32) {
+                            b->base = (addr & ~0xF);
+                            b->size = pci_bar_size(bus, slot, func, bar);
+                        } else {
+                            kprintf("Unknown mem bar type: %d\n", b->subtype);
+                            i--;
+                        }
+                    }
+                }
+                p->irq = pci_cfg_readb(bus, slot, func, PCI_INT_LINE);
+            }
+        }
+    }
+
+    return 0;
+}
+
+/**
+ * Dumps pci_devs.
+ * If file_name is defined, write them to file
+ * If print > 0, print to console
+ */
+int pci_dump(char *file_name, int print)
+{
+    fs_node_t *file = NULL;
+    char line[512];
+    int offs, n, i, j;
+    struct pci_dev *p;
+    if (file_name) {
+        if (fs_open_namei(file_name, O_WRONLY | O_CREAT, 0666, &file) < 0) {
+            kprintf("pci: cannot open %s\n", file_name);
+            return -1;
+        }
+    }
+    for (i = 0, offs = 0; i < PCI_MAX_DEVS; i++) {
+        p = &pci_devs.devs[i];
+        if (!p->vendor_id)
+            continue;
+        n = snprintf(line, sizeof(line), 
+                "%s\n  "
+                "vendor_id: %#x, device_id: %#x, "
+                "class: %#x, subclass: %#x, irq: %d\n",
+                pci_class_codes[p->class],
+                p->vendor_id, p->device_id, p->class, p->subclass, p->irq);
+        if (print)
+            kprintf("%s", line);
+        if (file) {
+            fs_write(file, offs, n, line);
+            offs += n;
+        }
+        for (j = 0; j < 6; j++) {
+            if (p->bars[j].base == 0)
+                continue;
+            n = snprintf(line, sizeof(line),
+                "  bar: %d, type: %s, base: %#x, size: %#x\n",
+                j, p->bars[j].type == PCI_BAR_MEM ? "mem":"io",
+                p->bars[j].base, p->bars[j].size);
+            if (print)
+                kprintf("%s", line);
+            if (file) {
+                fs_write(file, offs, n, line);
+                offs += n;
+            }
+        }
+    }
+    if (file)
+        fs_close(file);
+
+    return 0;
+}
+
+int pci_init()
+{
+    /* In theory vars on bss are clean, but, just in case */
+    memset(&pci_devs, 0, sizeof(pci_devs));
+    if (pci_scan() < 0) {
+        kprintf("Errors in scanning pci\n");
+        return -1;
+    }
+    //pci_dump("pci.txt", 1);
+    return 0;
+}
+

--- a/pci.h
+++ b/pci.h
@@ -1,0 +1,52 @@
+#ifndef _PCI_H
+#define _PCI_H
+#include <sys/types.h>
+
+#define PCI_MAX_DEVS 32 /* Max number of pci devices that we can handle */
+
+#define PCI_MAX_BARS 6
+#define PCI_BAR_MEM 0x0 /* MEM type BAR */
+#define PCI_BAR_IO 0x1  /* IO type BAR */
+#define PCI_BAR_PREFECHABLE 0x08
+
+#define PCI_BAR_MM32 0  /* 32 bit memory subtype BAR */
+#define PCI_BAR_MM64 2  /* 64 bit memory subtype BAR */
+
+struct pci_id {
+    uint16_t vendor_id;
+    uint16_t device_id;
+};
+
+/* Base Address Register representation */
+struct bar {
+    uint32_t base;      /* Base is memory address or port */
+    uint32_t size;      /* Size of memory address*/
+    uint8_t type;       /* Type, PCI_BAR_IO | PCI_BAR_MEM */
+    uint8_t subtype;    /* Subtype for PCI_BAR_MEM - MM32 - MM64*/
+};
+
+struct pci_dev {
+    uint8_t bus;
+    uint8_t slot;
+    uint8_t func;
+    uint16_t class;
+    uint16_t subclass;
+    uint16_t vendor_id;
+    uint16_t device_id;
+    struct bar bars[6];
+    uint8_t irq;
+    void *priv; /* Driver instance private data */
+};
+
+struct pci_devs {
+    struct pci_dev devs[PCI_MAX_DEVS];
+    int idx;
+};
+
+extern struct pci_devs pci_devs;
+
+int pci_dump(char *file_name, int print);
+int pci_init();
+
+#endif
+

--- a/syscall.c
+++ b/syscall.c
@@ -13,11 +13,11 @@ void exit(int status)
 {
     task_exit(status);
 }
-
+extern pid_t fork_int();
 static void *syscalls[] = {
     0,
 
-    &fork,
+    &fork_int,
     &task_wait,
     &task_exit,
     &getpid,

--- a/sysproc.c
+++ b/sysproc.c
@@ -58,8 +58,8 @@ int sys_exec(char *path, char *argv[])
     }
     if (S_ISREG(node->type) == 0)
         return -1;
-    if ((node->mask & (S_IXUSR | S_IXOTH | S_IXUSR)) == 0)
-        return -1;
+    //if ((node->mask & (S_IXUSR | S_IXOTH | S_IXUSR)) == 0)
+    //    return -1;
     if (fs_read(node, 0, sizeof(elf), (char *)&elf) != sizeof(elf))
         return -1;
     if (memcmp(elf.ident, ELF_MAGIC, strlen(ELF_MAGIC)) != 0)

--- a/task.c
+++ b/task.c
@@ -84,8 +84,6 @@ void task_init()
     }
     switch_locked = false;
     sti();
-    /* Switch task, to load registers */
-    task_switch();
 }
 
 void print_current_task()
@@ -189,9 +187,10 @@ task_t *task_switch_inner()
 }
 
 /**
- * Called from sched.asm
+ * Fork. Must be called from an interrupt, in order for
+ * registers to be properly saved.
  */
-pid_t fork()
+pid_t fork_int()
 {
     int fd;
     cli();

--- a/task.h
+++ b/task.h
@@ -120,7 +120,7 @@ void task_switch_next();
 /**
  * There is no spoon
  */
-pid_t fork();			// sched.asm
+pid_t fork();			// fork.asm
 
 /**
  * Dump current task

--- a/thread.c
+++ b/thread.c
@@ -82,11 +82,11 @@ task_t *thread_new(thread_fn fn, void *arg)
     //memcpy(t->sig_handlers, current_task->sig_handlers,
     //        NUM_SIGS * sizeof(*current_task->sig_handlers));
  
-    t->ebp = get_ebp();
-    t->esp = get_esp();
+    t->regs.ebp = get_ebp();
+    t->regs.esp = get_esp();
     get_last_task()->next = t;
     t->state = TASK_RUNNING;
-    t->eip = get_eip();
+    t->regs.eip = get_eip();
     /**
      * Here will jump the new created thread (child), after get_eip().
      * If current task is the new child, aka scheduler switched to it


### PR DESCRIPTION
Adds support for scanning PCI devices.
Driver for ne2k-pci (ne2000) network card.
WIP: networking and support for multiple cards.
To test network packages reception, you will need to add a bridge to
your system - $ sudo ip link add br0 type bridge, start the virtual
machine and ping it like: ping -I tap0 10.0.2.2. Also you can use
wireshark or tcpdump on tap0 to capture the traffic.
Packets should arrive inside cOSiris network queue.
Fixes: kernel space fork.