### PR TITLE
Add IPv4 and ICMP support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ OBJS = startup.o kernel.o i386.o port.o kinfo.o ring_buf.o \
 	   task.o fork.o thread.o sys.o syscall.o signal.o sysproc.o \
 	   list.o bname.o canonize.o \
 	   hd.o hd_queue.o cofs.o vfs.o pipe.o sysfile.o \
-	   net.o pci.o driver.o ne2000.o arp.o
+	   pci.o driver.o ne2000.o net.o arp.o ip.o icmp.o
 
 ifdef CONFIG_KDBG
 OBJS += kdbg.o kdbg0.o

--- a/arp.c
+++ b/arp.c
@@ -263,7 +263,7 @@ int arp_resolve(uint32_t ip, uint8_t mac[6])
     eth = (eth_hdr_t *) buf->data;
     memset(eth->dmac, 0xFF, MAC_SIZE);
     memcpy(eth->smac, netif->mac, MAC_SIZE);
-    eth->eth_type = ETH_ARP;
+    eth->eth_type = ETH_P_ARP;
     eth2buf(eth);
 
     /* ARP header */

--- a/icmp.c
+++ b/icmp.c
@@ -1,0 +1,98 @@
+#include <string.h>
+#include <arpa/inet.h>
+#include "console.h"
+#include "net.h"
+#include "ip.h"
+#include "icmp.h"
+
+static struct icmpv4_hdr *buf2icmpv4(void *buf)
+{
+    struct icmpv4_hdr *icmph = buf;
+    icmph->csum = ntohs(icmph->csum);
+
+    return icmph;
+}
+
+static void *icmpv42buf(struct icmpv4_hdr *icmph)
+{
+    icmph->csum = htons(icmph->csum);
+
+    return icmph;
+}
+
+struct icmpv4_echo *buf2echo(void *buf)
+{
+    struct icmpv4_echo *echo = buf;
+    echo->id = ntohs(echo->id);
+    echo->seq = ntohs(echo->seq);
+
+    return echo;
+}
+
+/**
+ * Replies to an ICMP echo packet, reusing recv buffer (echo data back).
+ * Expects buf->data to be in host format.
+ */
+static int icmpv4_echo_reply(struct net_buf *buf)
+{
+    struct netif *netif = &netifs[buf->nic];
+    eth_hdr_t *eth = buf->data;
+    ipv4_hdr_t *iph = (ipv4_hdr_t *) eth->data;
+    struct icmpv4_hdr *icmph;
+
+    /* ICMP header */
+    icmph = (struct icmpv4_hdr *)((uint8_t *)iph + (iph->ihl * 4));
+    icmph->type = ICMP_T_ECHO_REPLAY;
+    icmph->code = icmph->csum = 0;
+    icmpv42buf(icmph);
+    icmph->csum = ip_csum(icmph, iph->len - sizeof(*iph));
+
+    /* IP header */
+    uint32_t dip = iph->daddr;
+    iph->daddr = iph->saddr;
+    iph->saddr = dip;
+    iph->ttl = 64;
+    iph->csum = 0;
+    ipv42buf(iph);
+    iph->csum = ip_csum(iph, iphlen(iph));
+
+    /* Ethernet */
+    memcpy(eth->dmac, eth->smac, MAC_SIZE);
+    memcpy(eth->smac, netif->mac, MAC_SIZE);
+    eth2buf(eth);
+
+    netif->send(netif, buf->data, buf->size);
+
+    return 0;
+}
+
+/**
+ * Called when we received an ICMP.
+ * Expects buf->data to be in host format
+ */
+int icmpv4_process(struct net_buf *buf)
+{
+    eth_hdr_t *eth = buf->data;
+    ipv4_hdr_t *iph = (ipv4_hdr_t *) eth->data;
+    struct icmpv4_hdr *icmph = (void *)((uint8_t *)iph + (iph->ihl * 4));
+    uint16_t csum = ip_csum(icmph, iph->len - sizeof(*iph));
+
+    if (csum != 0)
+        return -1;
+
+    icmph = buf2icmpv4(icmph);
+
+    switch (icmph->type) {
+        case ICMP_T_ECHO_REQUEST:
+            icmpv4_echo_reply(buf);
+            break;
+        case ICMP_T_DEST_UNREACHABLE:
+            kprintf("Got Dest Unreachable\n");
+            break;
+        default:
+            kprintf("ICMPV4 type %d not supported\n", icmph->type);
+            break;
+    }
+    return 0;
+}
+

--- a/icmp.h
+++ b/icmp.h
@@ -1,0 +1,25 @@
+#ifndef _ICMP_H
+#define _ICMP_H
+
+#include "net.h"
+
+struct icmpv4_hdr {
+    uint8_t type;
+    uint8_t code;
+    uint16_t csum;
+    uint8_t data[];
+} __attribute__((packed));
+
+struct icmpv4_echo {
+    uint16_t id;
+    uint16_t seq;
+    uint8_t data[];
+} __attribute__((packed));
+
+int icmpv4_process(struct net_buf *buf);
+
+#define ICMP_T_ECHO_REPLAY 0
+#define ICMP_T_DEST_UNREACHABLE 3
+#define ICMP_T_ECHO_REQUEST 8
+
+#endif

--- a/ip.c
+++ b/ip.c
@@ -1,0 +1,155 @@
+#include <arpa/inet.h>
+#include <string.h>
+#include "console.h"
+#include "net.h"
+#include "icmp.h"
+#include "ip.h"
+
+/**
+ * Computes the checksum of the buffer having length
+ * DOCS: https://tools.ietf.org/html/rfc1071
+ */
+uint16_t ip_csum(void *buf, int len)
+{
+    uint32_t sum = 0; 
+    uint16_t *ptr = buf;
+
+    while (len > 1) {
+        sum += *ptr++;
+        len -= 2;
+    }
+    if (len > 0)
+        sum += *(uint8_t *) ptr;
+    while (sum >> 16)
+        sum = (sum & 0xFFFF) + (sum >> 16);
+
+    return ~sum;
+}
+
+/**
+ * An ugly function to dump an IP header
+ */
+void ipv4_hdr_dump(ipv4_hdr_t *iph)
+{
+    kprintf("version: %d\n", iph->version);
+    kprintf("ihl: %d (%d bytes)\n", iph->ihl, iph->ihl * 4);
+    kprintf("tos: %d\n", iph->tos);
+    kprintf("total length: %d bytes\n", iph->len);
+    kprintf("id: %#x\n", iph->id);
+    kprintf("flags: %#x\n", iph->flags);
+    kprintf("fragment offset: %#x (%#x bytes)\n", 
+            iph->frag_offs, iph->frag_offs << 3);
+    kprintf("ttl: %d\n", iph->ttl);
+    kprintf("protocol: %d\n", iph->proto);
+    kprintf("csum: %#x %s\n", iph->csum);
+    kprintf("saddr: ");
+    print_ip(iph->saddr);
+    kprintf("\n");
+    kprintf("daddr: ");
+    print_ip(iph->daddr);
+    kprintf("\n");
+}
+
+/**
+ * Gets the length of the IP header.
+ *  buf is the start of the IP header, in network format.
+ */
+int iphlen(void *buf)
+{
+    uint8_t hlen = *(uint8_t *)buf;
+
+    if (is_bige)
+        hlen = (hlen >> 4);
+
+    return (hlen & 0x07) << 2;
+}
+
+/**
+ * Converts from network format IP header into internal representation
+ */
+static ipv4_hdr_t *buf2ipv4(void *buf)
+{
+    ipv4_hdr_t *iph = buf;
+
+    if (!is_bige) {
+        uint8_t ihl = iph->version;
+        iph->version = iph->ihl;
+        iph->ihl = ihl;
+        uint16_t frg = ntohs(*((uint16_t *)iph + 3));
+        iph->flags = (frg >> 13) & 0x7;
+        iph->frag_offs = frg & 0x1FFF;
+    }
+    iph->len = ntohs(iph->len);
+    iph->id = ntohs(iph->id);
+    iph->csum = ntohs(iph->csum);
+    iph->saddr = ntohl(iph->saddr);
+    iph->daddr = ntohl(iph->daddr);
+
+    return iph;
+}
+
+/**
+ * Converts an IP header to network format
+ */
+void *ipv42buf(ipv4_hdr_t *iph)
+{
+    if (!is_bige) {
+        uint8_t ihl = iph->version;
+        iph->version = iph->ihl;
+        iph->ihl = ihl;
+        uint16_t *ptr = (uint16_t *)iph + 3;
+        uint16_t val = *ptr;
+        // XXX more tests here!
+        *ptr = htons(((val & 0x7) << 13) | ((val & ~0x7) >> 3));
+    }
+    iph->len = ntohs(iph->len);
+    iph->id = ntohs(iph->id);
+    iph->csum = ntohs(iph->csum);
+    iph->saddr = ntohl(iph->saddr);
+    iph->daddr = ntohl(iph->daddr);
+
+    return iph;
+}
+
+/**
+ * Process an IP packet.
+ * Expects buf->data to be in network format.
+ */
+int ip_process(struct net_buf *buf)
+{
+    int i;
+    eth_hdr_t *eth = buf2eth(buf->data);
+    uint16_t csum = ip_csum(eth->data, iphlen(eth->data));
+    ipv4_hdr_t *iph = buf2ipv4(eth->data);
+    struct netif *netif = &netifs[buf->nic];
+
+    //ipv4_hdr_dump(iph);
+
+    if (iph->version != IPV4)
+        return -1;
+    if (iph->ihl < 5)
+        return -1;
+    if (iph->ttl == 0)
+        return -1;
+    if (csum != 0)
+        return -1;
+
+    /* Is this packet for us? */
+    for (i = 0; i < IFACE_MAX_IPS; i++)
+        if (netif->ips[i] == iph->daddr)
+            break;
+    if (i == IFACE_MAX_IPS)
+        return -1;
+
+    switch (iph->proto) {
+        case ICMPV4:
+            icmpv4_process(buf);
+            break;
+        default:
+            kprintf("Unsupported IP header protocol: %d\n", iph->proto);
+            break;
+    }
+
+    return 0;
+}
+

--- a/ip.h
+++ b/ip.h
@@ -1,0 +1,35 @@
+#ifndef _IP_H
+#define _IP_H
+
+#include <sys/types.h>
+
+struct ipv4_hdr {
+    uint8_t version : 4;
+    uint8_t ihl : 4;
+    uint8_t tos;
+    uint16_t len;
+    uint16_t id;
+    uint16_t flags : 3;
+    uint16_t frag_offs : 13;
+    uint8_t ttl;
+    uint8_t proto;
+    uint16_t csum;
+    uint32_t saddr;
+    uint32_t daddr;
+} __attribute__ ((packed));
+
+typedef struct ipv4_hdr ipv4_hdr_t;
+
+#define IPV4 4
+
+uint16_t ip_csum(void *buf, int len);
+
+int ip_process(struct net_buf *buf);
+
+void *ipv42buf(ipv4_hdr_t *iph);
+
+int iphlen(void *buf);
+
+#define ICMPV4 1
+
+#endif

--- a/net.h
+++ b/net.h
@@ -76,7 +76,10 @@ void print_mac(uint8_t mac[6]);
 eth_hdr_t *buf2eth(void *buf);
 void *eth2buf(eth_hdr_t *eth);
 
-#define ETH_ARP 0x0806
+#define ETH_P_ARP 0x0806
+#define ETH_P_IP 0x0800
+
+int is_bige;
 
 #endif
 

--- a/net.sh
+++ b/net.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Run this on devel platform (host) startup.
+# Modify it to suit your needs.
+
+sudo ip link add br0 type bridge
+sudo sysctl -w net.ipv4.ip_forward=1
+sudo ip link set br0 up
+sudo route add -host 10.0.2.3 dev br0
+sudo route add -host 10.0.2.4 dev br0
+

--- a/todo.txt
+++ b/todo.txt
@@ -30,4 +30,6 @@
       use gcc __umoddi3/__udivdi3 or rewrite them
     - printf should be buffered - use fprintf
     + write a sscanf function - vsscanf, no floating point support yet.
+    - ntoh* hton* should check host endianness and do nothing on big endian 
+       platforms.
 


### PR DESCRIPTION
Adds IPv4 support. cOSiris can now reply to ICMP echo packets.
To setup host in order to bridge QEMU with it, check net.sh
and modify to your needs.